### PR TITLE
No sense lastInsertId method visibility

### DIFF
--- a/W/Model/Model.php
+++ b/W/Model/Model.php
@@ -348,7 +348,7 @@ abstract class Model
 	 * Retourne l'identifiant de la dernière ligne insérée
 	 * @return int L'identifiant
 	 */
-	public function lastInsertId()
+	protected function lastInsertId()
 	{
 		return $this->dbh->lastInsertId();
 	}


### PR DESCRIPTION
I think there is no sense that lastInsertId method is public. Only interest of this method is to use that in custom method that developer can write in its own model. Do you agree ?