### PR TITLE
Fix autoloading functions in global namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "psr-4": {
             "W\\": "W/",
             "": "app/"
-        }
+        },
+        "files": ["W/globals.php"]
     },
     "repositories": [
         {


### PR DESCRIPTION
globals.php has been removed from require in index.php at a4d15f0
But we need to add it to autoloading in composer.